### PR TITLE
take over the 'SystemRoot' variable on Windows

### DIFF
--- a/src/main/java/hudson/plugins/script_realm/ScriptSecurityRealm.java
+++ b/src/main/java/hudson/plugins/script_realm/ScriptSecurityRealm.java
@@ -36,7 +36,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -80,7 +82,13 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 		try {
 			StringWriter out = new StringWriter();
 			LocalLauncher launcher = new LoginScriptLauncher(new StreamTaskListener(out));
-			if (launcher.launch().cmds(QuotedStringTokenizer.tokenize(commandLine)).stdout(new NullOutputStream()).envs("U=" + username, "P=" + password)
+			Map<String,String> overrides = new HashMap<String, String>();
+			overrides.put("U", username);
+			overrides.put("P", password);
+			if (System.getProperty("os.name").toLowerCase().contains("win")) {
+				overrides.put("SystemRoot", System.getenv("SystemRoot"));
+			}
+			if (launcher.launch().cmds(QuotedStringTokenizer.tokenize(commandLine)).stdout(new NullOutputStream()).envs(overrides)
 					.join() != 0) {
 				throw new BadCredentialsException(out.toString());
 			}


### PR DESCRIPTION
I encounter a SocketException when executing the custom script on Windows.The stacktrace is like below.

> java.net.SocketException@89cc5e detailMessage=Unrecognized Windows Sockets error: 10106: create cause=java.net.SocketException: Unrecognized Windows Sockets error: 10106: create stackTrace=null

I research this exception, and I think it is lack the environment variable 'SystemRoot'[1]. So I modify taking over the 'SystemRoot' variable when Windows.It works for me both Windows XP and Windows 7.

[1] http://www.coderanch.com/t/207423/sockets/java/java-net-SocketException-Unrecognized-Windows
