### PR TITLE
Adds a log when command triggers an exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /.project
-/.classpath
-/.settings
 /target
 /work

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.project
+/.classpath
+/.settings
 /target
 /work

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-	   <groupId>org.jenkins-ci.plugins</groupId>
-	   <artifactId>plugin</artifactId>
-	   <version>1.566</version>
+		<groupId>org.jvnet.hudson.plugins</groupId>
+		<artifactId>plugin</artifactId>
+		<version>1.330</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>script-realm</artifactId>
 	<version>1.6-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 	<name>Security Realm by custom script</name>
-	<description>Supports authentication by executing a custom script, to resolve groups for a user, a second script can be defined.</description>
+	<description>Supports authentication by exeuting a custom script, to resolve groups for a user, a second script can be defined.</description>
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -20,6 +21,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
+				<version>2.0</version>
 				<configuration>
 					<goals>deploy</goals>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.hudson.plugins</groupId>
-		<artifactId>plugin</artifactId>
-		<version>1.330</version>
-		<relativePath>../pom.xml</relativePath>
+	   <groupId>org.jenkins-ci.plugins</groupId>
+	   <artifactId>plugin</artifactId>
+	   <version>1.566</version>
 	</parent>
 
 	<artifactId>script-realm</artifactId>
 	<version>1.6-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 	<name>Security Realm by custom script</name>
-	<description>Supports authentication by exeuting a custom script, to resolve groups for a user, a second script can be defined.</description>
+	<description>Supports authentication by executing a custom script, to resolve groups for a user, a second script can be defined.</description>
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -21,7 +20,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.0</version>
 				<configuration>
 					<goals>deploy</goals>
 				</configuration>

--- a/src/main/java/hudson/plugins/script_realm/LoginScriptLauncher.java
+++ b/src/main/java/hudson/plugins/script_realm/LoginScriptLauncher.java
@@ -12,6 +12,10 @@ import hudson.model.TaskListener;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 
 /**
  * This launcher does not expand the given environment variables - this is
@@ -23,6 +27,9 @@ import java.io.IOException;
  * 
  */
 public class LoginScriptLauncher extends LocalLauncher {
+
+	private static final String CLASSNAME = LoginScriptLauncher.class.getName();
+	private static final Logger LOGGER = Logger.getLogger(CLASSNAME);
 
 	public LoginScriptLauncher(TaskListener listener) {
 		super(listener);
@@ -40,7 +47,13 @@ public class LoginScriptLauncher extends LocalLauncher {
 			jobCmd[idx] = jobEnv.expand(ps.cmds().get(idx));
 		}
 
-		return new hudson.Proc.LocalProc(jobCmd, Util.mapToEnv(jobEnv), ps.stdin(), ps.stdout(), ps.stderr(), toFile(ps.pwd()));
+		try {
+			return new hudson.Proc.LocalProc(jobCmd, Util.mapToEnv(jobEnv), ps.stdin(), ps.stdout(), ps.stderr(), toFile(ps.pwd()));
+		} catch ( IOException e ) {
+			// logs useful details about the command being run like variables as they were replaced
+			LOGGER.log(Level.SEVERE, String.format("Error while executing command %s",Arrays.toString(jobCmd)), e);
+			throw e;
+		}
 	}
 
 	private File toFile(FilePath f) {


### PR DESCRIPTION
This change logs the final command (with variables values as they were replaced) as well as the full stack trace when an IOException occurs on running the command.

It's useful to elaborate the authentication command or to debug it.

Sample log output :

```
26-Sep-2015 00:55:01.933 SEVERE [Handling POST /jenkins/j_acegi_security_check from 127.0.0.1 : http-nio-8080-exec-10] hudson.plugins.script_realm.LoginScriptLauncher.launch Error while executing command [beurk]
 java.io.IOException: Cannot run program "beurk": error=2, No such file or directory
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
        at hudson.Proc$LocalProc.<init>(Proc.java:244)
        at hudson.Proc$LocalProc.<init>(Proc.java:216)
        at hudson.plugins.script_realm.LoginScriptLauncher.launch(LoginScriptLauncher.java:51)
        at hudson.Launcher$ProcStarter.start(Launcher.java:382)
        at hudson.Launcher$ProcStarter.join(Launcher.java:389)
        at hudson.plugins.script_realm.ScriptSecurityRealm.authenticate(ScriptSecurityRealm.java:91)
        at hudson.security.AbstractPasswordBasedSecurityRealm.doAuthenticate(AbstractPasswordBasedSecurityRealm.java:114)
        at hudson.security.AbstractPasswordBasedSecurityRealm.access$100(AbstractPasswordBasedSecurityRealm.java:39)
        at hudson.security.AbstractPasswordBasedSecurityRealm$Authenticator.retrieveUser(AbstractPasswordBasedSecurityRealm.java:148)
        at org.acegisecurity.providers.dao.AbstractUserDetailsAuthenticationProvider.authenticate(AbstractUserDetailsAuthenticationProvider.java:122)
        at org.acegisecurity.providers.ProviderManager.doAuthentication(ProviderManager.java:200)
        at org.acegisecurity.AbstractAuthenticationManager.authenticate(AbstractAuthenticationManager.java:47)
        at org.acegisecurity.ui.webapp.AuthenticationProcessingFilter.attemptAuthentication(AuthenticationProcessingFilter.java:74)
        at org.acegisecurity.ui.AbstractProcessingFilter.doFilter(AbstractProcessingFilter.java:252)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
        at jenkins.security.BasicHeaderProcessor.doFilter(BasicHeaderProcessor.java:93)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
        at org.acegisecurity.context.HttpSessionContextIntegrationFilter.doFilter(HttpSessionContextIntegrationFilter.java:249)
        at hudson.security.HttpSessionContextIntegrationFilter2.doFilter(HttpSessionContextIntegrationFilter2.java:67)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
        at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:76)
        at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:171)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:49)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:81)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at org.kohsuke.stapler.DiagnosticThreadNameFilter.doFilter(DiagnosticThreadNameFilter.java:30)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:219)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:106)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:614)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:142)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:79)
        at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:610)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:88)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:518)
        at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1091)
        at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:668)
        at org.apache.coyote.http11.Http11NioProtocol$Http11ConnectionHandler.process(Http11NioProtocol.java:223)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1517)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1474)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.lang.Thread.run(Thread.java:722)
Caused by: java.io.IOException: error=2, No such file or directory
        at java.lang.UNIXProcess.forkAndExec(Native Method)
        at java.lang.UNIXProcess.<init>(UNIXProcess.java:135)
        at java.lang.ProcessImpl.start(ProcessImpl.java:130)
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1021)
        ... 50 more
```
