### PR TITLE
I18n fr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.project
+/.classpath
+/.settings
 /target
 /work

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-Modular Script Realm plugin for Jenkins
-=======================================
+Script Realm plugin for Jenkins
+===============================
 
-This fork of the "Script Realm" plugin for Jenkins adds e-mail and display name resolution support.
-
-The original plugin allows to use a user-written custom script to authenticate the username and password (also supports groups).
+This Jenkins plugin allows you to use a user-written custom script to authenticate the username and password (also supports groups). 
 This is useful if you need to plug into a custom authentication scheme, but don't want to write your own plugin.
-Find more about the original plugin at https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm.
 
-By default this plugin triggers any `MailAddressResolver` and `UserNameResolver` installed on the Jenkins instance.
-You may also disable resolution or use a specific resolver for each of them.
+Find more at https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm.
 
-For instance, the [LDAP Email Plugin](https://wiki.jenkins-ci.org/display/JENKINS/LDAP+Email+Plugin) provides a `MailAddressResolver`. If installed, you may configure "Modular Script Realm" to use a custom script to authenticate users and the "LDAP Email Plugin" to resolve their e-mail.
+
+Resolving e-mail and full name
+------------------------------
+
+In order to display e-mail and full name in the authenticated users' page, this plugin triggers any `MailAddressResolver` and `UserNameResolver` installed on the Jenkins instance.
+You may disable resolution or use a specific resolver for each of them.
+
+For instance, the [LDAP Email Plugin](https://wiki.jenkins-ci.org/display/JENKINS/LDAP+Email+Plugin) provides a `MailAddressResolver`.
 
 Since this plugin does not know how resolvers from external plugins are to be configured, using a random resolver might not work at all.
-
-You will soon find here a list of known working configurations.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
-Script Realm plugin for Jenkins
-===============================
+Modular Script Realm plugin for Jenkins
+=======================================
 
-This Jenkins plugin allows you to use a user-written custom script to authenticate the username and password (also supports groups). 
+This fork of the "Script Realm" plugin for Jenkins adds e-mail and display name resolution support.
+
+The original plugin allows to use a user-written custom script to authenticate the username and password (also supports groups).
 This is useful if you need to plug into a custom authentication scheme, but don't want to write your own plugin.
+Find more about the original plugin at https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm.
 
-find more at https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm
+By default this fork triggers any `MailAddressResolver` and `UserNameResolver` installed on the Jenkins instance.
+You can disable resolution for e-mail and/or display name or use a specific resolver.
 
+For instance, the [LDAP Email Plugin](https://wiki.jenkins-ci.org/display/JENKINS/LDAP+Email+Plugin) provides a `MailAddressResolver`. If installed, you may configure "Modular Script Realm" to use a custom script to authenticate users and the "LDAP Email Plugin" to resolve their e-mail.
+
+Since this plugin does not know how resolvers from external plugins are to be configured, using a random resolver might not work at all.
+
+You will soon find here a list of known working configurations.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The original plugin allows to use a user-written custom script to authenticate t
 This is useful if you need to plug into a custom authentication scheme, but don't want to write your own plugin.
 Find more about the original plugin at https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm.
 
-By default this fork triggers any `MailAddressResolver` and `UserNameResolver` installed on the Jenkins instance.
-You can disable resolution for e-mail and/or display name or use a specific resolver.
+By default this plugin triggers any `MailAddressResolver` and `UserNameResolver` installed on the Jenkins instance.
+You may also disable resolution or use a specific resolver for each of them.
 
 For instance, the [LDAP Email Plugin](https://wiki.jenkins-ci.org/display/JENKINS/LDAP+Email+Plugin) provides a `MailAddressResolver`. If installed, you may configure "Modular Script Realm" to use a custom script to authenticate users and the "LDAP Email Plugin" to resolve their e-mail.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 	   <version>1.566</version>
 	</parent>
 
-	<artifactId>script-realm-modular</artifactId>
+	<artifactId>script-realm</artifactId>
 	<version>1.6-SNAPSHOT</version>
 	<packaging>hpi</packaging>
-	<name>Security Realm by custom script using modular resolvers</name>
-	<description>Supports authentication by custom script, groups resolving for a user, and triggers e-mail and name resolvers.</description>
+	<name>Security Realm by custom script</name>
+	<description>Supports authentication by custom script, groups resolving for a user, and triggers e-mail and full name resolvers.</description>
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -50,7 +50,7 @@
 		<developer>
 			<id>nicobo</id>
 			<name>Nicolas BONARDELLE</name>
-			<url>http://nicolabs.xyz/people/nicobo</url>
+			<url>http://nicolabs.net/contact</url>
 		</developer>
     </developers>	
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
 	</parent>
 
 	<artifactId>script-realm</artifactId>
-	<version>1.6-emailfullnameresolvers-SNAPSHOT</version>
+	<version>1.6-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 	<name>Security Realm by custom script</name>
 	<description>Supports authentication by custom script, groups resolving for a user, and triggers e-mail and full name resolvers.</description>
-	<url>https://github.com/nicolabs/script-realm-plugin</url>
+	<url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -47,16 +47,11 @@
             <name>Dominik Bartholdi</name>
             <email>-</email>
         </developer>
-		<developer>
-			<id>nicobo</id>
-			<name>Nicolas BONARDELLE</name>
-			<url>http://nicolabs.net/contact</url>
-		</developer>
     </developers>	
 	<scm>
-		<connection>scm:git:git://github.com/nicolabs/script-realm-plugin.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/nicolabs/script-realm-plugin.git</developerConnection>
-		<url>https://github.com/nicolabs/script-realm-plugin</url>
+		<connection>scm:git:git://github.com/jenkins/script-realm-plugin.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/script-realm-plugin.git</developerConnection>
+		<url>http://github.com/jenkins/script-realm-plugin</url>
 	</scm>
 	<distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<packaging>hpi</packaging>
 	<name>Security Realm by custom script</name>
 	<description>Supports authentication by custom script, groups resolving for a user, and triggers e-mail and full name resolvers.</description>
-	<url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm</url>
+	<url>https://github.com/nicolabs/script-realm-plugin</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -54,9 +54,9 @@
 		</developer>
     </developers>	
 	<scm>
-		<connection>scm:git:git://github.com/jenkins/script-realm-plugin.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/script-realm-plugin.git</developerConnection>
-		<url>http://github.com/jenkins/script-realm-plugin</url>
+		<connection>scm:git:git://github.com/nicolabs/script-realm-plugin.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/nicolabs/script-realm-plugin.git</developerConnection>
+		<url>https://github.com/nicolabs/script-realm-plugin</url>
 	</scm>
 	<distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 	   <version>1.566</version>
 	</parent>
 
-	<artifactId>script-realm</artifactId>
+	<artifactId>script-realm-modular</artifactId>
 	<version>1.6-SNAPSHOT</version>
 	<packaging>hpi</packaging>
-	<name>Security Realm by custom script</name>
-	<description>Supports authentication by executing a custom script, to resolve groups for a user, a second script can be defined.</description>
+	<name>Security Realm by custom script using modular resolvers</name>
+	<description>Supports authentication by custom script, groups resolving for a user, and triggers e-mail and name resolvers.</description>
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -33,12 +33,25 @@
 			</plugin>
 		</plugins>
 	</build>
+	<dependencies>
+		<!-- Required for e-mail resolving (MailAddressResolver,...) -->
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>mailer</artifactId>
+			<version>1.8</version>
+		</dependency>
+	</dependencies>
     <developers>
         <developer>
             <id>imod</id>
             <name>Dominik Bartholdi</name>
             <email>-</email>
         </developer>
+		<developer>
+			<id>nicobo</id>
+			<name>Nicolas BONARDELLE</name>
+			<url>http://nicolabs.xyz/people/nicobo</url>
+		</developer>
     </developers>	
 	<scm>
 		<connection>scm:git:git://github.com/jenkins/script-realm-plugin.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 
 	<artifactId>script-realm</artifactId>
-	<version>1.6-SNAPSHOT</version>
+	<version>1.6-emailfullnameresolvers-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 	<name>Security Realm by custom script</name>
 	<description>Supports authentication by custom script, groups resolving for a user, and triggers e-mail and full name resolvers.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.hudson.plugins</groupId>
-		<artifactId>plugin</artifactId>
-		<version>1.330</version>
-		<relativePath>../pom.xml</relativePath>
+	   <groupId>org.jenkins-ci.plugins</groupId>
+	   <artifactId>plugin</artifactId>
+	   <version>1.566</version>
 	</parent>
 
 	<artifactId>script-realm</artifactId>
 	<version>1.6-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 	<name>Security Realm by custom script</name>
-	<description>Supports authentication by exeuting a custom script, to resolve groups for a user, a second script can be defined.</description>
+	<description>Supports authentication by executing a custom script, to resolve groups for a user, a second script can be defined.</description>
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -21,7 +20,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.0</version>
 				<configuration>
 					<goals>deploy</goals>
 				</configuration>

--- a/src/main/java/hudson/plugins/script_realm/ScriptSecurityRealm.java
+++ b/src/main/java/hudson/plugins/script_realm/ScriptSecurityRealm.java
@@ -146,7 +146,7 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 	public static final class DescriptorImpl extends Descriptor<SecurityRealm> {
 
 		public String getDisplayName() {
-			return "Authenticate via custom script";
+			return Messages.ScriptSecurityRealm_displayName();
 		}
 
 		public String getDefaultEmailResolver() {

--- a/src/main/java/hudson/plugins/script_realm/ScriptSecurityRealm.java
+++ b/src/main/java/hudson/plugins/script_realm/ScriptSecurityRealm.java
@@ -24,13 +24,19 @@
 package hudson.plugins.script_realm;
 
 import hudson.Extension;
+import hudson.ExtensionList;
 import hudson.Launcher.LocalLauncher;
 import hudson.model.Descriptor;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
 import hudson.security.GroupDetails;
 import hudson.security.SecurityRealm;
+import hudson.tasks.MailAddressResolver;
+import hudson.tasks.UserNameResolver;
+import hudson.tasks.Mailer;
 import hudson.util.QuotedStringTokenizer;
 import hudson.util.StreamTaskListener;
+import hudson.util.ListBoxModel;
+import hudson.util.ListBoxModel.Option;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -59,16 +65,28 @@ import org.springframework.dao.DataAccessException;
 
 /**
  * @author Kohsuke Kawaguchi
+ * @author nicobo
  */
 public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
+
 	private static final Logger LOGGER = Logger.getLogger(ScriptSecurityRealm.class.getName());
+
+	/** Strategy : call the global resolve method (let Jenkins choose) */
+	private static final String OPTION_RESOLVER_DEFAULTSTRATEGY = "*";
+	/** Strategy : don't resolve */
+	private static final String OPTION_RESOLVER_NONESTRATEGY = "";
+
 
 	public final String commandLine;
 	public final String groupsCommandLine;
 	public final String groupsDelimiter;
+	/** The name of the e-mail resolver to use */
+	public final String emailResolver;
+	/** The name of the full name resolver to user */
+	public final String nameResolver;
 
 	@DataBoundConstructor
-	public ScriptSecurityRealm(String commandLine, String groupsCommandLine, String groupsDelimiter) {
+	public ScriptSecurityRealm(String commandLine, String groupsCommandLine, String groupsDelimiter, String emailResolver, String nameResolver) {
 		this.commandLine = commandLine;
 		this.groupsCommandLine = groupsCommandLine;
 		if (StringUtils.isBlank(groupsDelimiter)) {
@@ -76,9 +94,13 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 		} else {
 			this.groupsDelimiter = groupsDelimiter;
 		}
+		this.emailResolver = emailResolver;
+		this.nameResolver = nameResolver;
+		LOGGER.log(Level.FINE, "Configured with : commandLine=[{0}] groupsCommandLine=[{1}] groupsDelimiter=[{2}] emailResolver=[{3}] nameResolver=[{4}]", new Object[]{commandLine,groupsCommandLine,groupsDelimiter,emailResolver,nameResolver});
 	}
 
 	protected UserDetails authenticate(String username, String password) throws AuthenticationException {
+		LOGGER.entering(ScriptSecurityRealm.class.getName(), "authenticate", new Object[]{username,password});
 		try {
 			StringWriter out = new StringWriter();
 			LocalLauncher launcher = new LoginScriptLauncher(new StreamTaskListener(out));
@@ -88,11 +110,17 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 			if (isWindows()) {
 				overrides.put("SystemRoot", System.getenv("SystemRoot"));
 			}
+			LOGGER.log(Level.FINE,"Executing command with U=[{0}], P=[{1}]", new Object[]{username,password});
 			if (launcher.launch().cmds(QuotedStringTokenizer.tokenize(commandLine)).stdout(new NullOutputStream()).envs(overrides).join() != 0) {
 				throw new BadCredentialsException(out.toString());
 			}
 			GrantedAuthority[] groups = loadGroups(username);
-			return new User(username, "", true, true, true, true, groups);
+
+			User user = new User(username, "", true, true, true, true, groups);
+
+			updateUserDetails(username);
+
+			return user;
 		} catch (InterruptedException e) {
 			throw new AuthenticationServiceException("Interrupted", e);
 		} catch (IOException e) {
@@ -116,12 +144,52 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 
 	@Extension
 	public static final class DescriptorImpl extends Descriptor<SecurityRealm> {
+
 		public String getDisplayName() {
 			return "Authenticate via custom script";
 		}
+
+		public String getDefaultEmailResolver() {
+			return OPTION_RESOLVER_DEFAULTSTRATEGY;
+		}
+
+		public String getDefaultNameResolver() {
+			return OPTION_RESOLVER_DEFAULTSTRATEGY;
+		}
+
+		public ListBoxModel doFillEmailResolverItems() {
+            ListBoxModel items = new ListBoxModel();
+            ExtensionList<MailAddressResolver> mars = MailAddressResolver.all();
+            items.add(new Option(Messages.ScriptSecurityRealm_EmailResolver_defaultstrategy_label(),OPTION_RESOLVER_DEFAULTSTRATEGY));	// This entry will use Jenkins's default behavior (calling all found resolvers)
+            if ( ! mars.isEmpty() ) {
+                items.add(new Option(Messages.ScriptSecurityRealm_EmailResolver_nonestrategy_label(),OPTION_RESOLVER_NONESTRATEGY));	// This entry will disable resolving if selected
+	            // Adds all found e-mail resolvers as options so the user can select one of them
+	            for (MailAddressResolver mar : mars) {
+	            	// class name is used both as label and value
+	                items.add(mar.getClass().getCanonicalName(),mar.getClass().getName());
+	            }
+            }
+            return items;
+        }
+
+		public ListBoxModel doFillNameResolverItems() {
+            ListBoxModel items = new ListBoxModel();
+            ExtensionList<UserNameResolver> unrs = UserNameResolver.all();
+            items.add(new Option(Messages.ScriptSecurityRealm_NameResolver_defaultstrategy_label(),OPTION_RESOLVER_DEFAULTSTRATEGY));	// This entry will use Jenkins's default behavior (calling all found resolvers)
+            if ( ! unrs.isEmpty() ) {
+                items.add(new Option(Messages.ScriptSecurityRealm_NameResolver_nonestrategy_label(),OPTION_RESOLVER_NONESTRATEGY));	// This entry will disable resolving if selected
+	            // Adds all found name resolvers as options so the user can select one of them
+	            for (UserNameResolver unr : unrs) {
+	            	// class name is used both as label and value
+	                items.add(unr.getClass().getCanonicalName(),unr.getClass().getName());
+	            }
+            }
+            return items;
+        }
 	}
 
 	protected GrantedAuthority[] loadGroups(String username) throws AuthenticationException {
+		LOGGER.log(Level.FINE,"Loading groups from command for {0}", new Object[]{username});
 		try {
 			List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
 			authorities.add(AUTHENTICATED_AUTHORITY);
@@ -154,6 +222,74 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 			throw new AuthenticationServiceException("Failed", e);
 		}
 	}
+
+    /**
+     * Updates the display name and e-mail address of the user by calling the chosen resolvers.
+     * Most of the code comes from {@link hudson.security.LDAPSecurityRealm}.
+     */
+    private void updateUserDetails(String username) {
+
+        hudson.model.User user = hudson.model.User.get(username);
+
+        if ( !OPTION_RESOLVER_NONESTRATEGY.equals(nameResolver) ) {
+        	String fullname = null;
+        	if ( OPTION_RESOLVER_DEFAULTSTRATEGY.equals(nameResolver) ) {
+        		LOGGER.log(Level.FINE,"Calling any registered UserNameResolver for {0}",new Object[]{user});
+        		fullname = UserNameResolver.resolve(user);
+        	} else {
+                for (UserNameResolver unr : UserNameResolver.all()) {
+                	if ( unr.getClass().getName().equals(nameResolver) ) {
+                		LOGGER.log(Level.FINE,"Calling resolver {0} for {1}",new Object[]{nameResolver,user});
+                		fullname = unr.findNameFor(user);
+                		break;
+                	}
+            		LOGGER.log(Level.WARNING,"Resolver {0} not found : name not updated",new Object[]{nameResolver});
+                }
+        	}
+        	if ( StringUtils.isNotBlank(fullname) ) {
+        		LOGGER.log(Level.FINE,"Setting user's name to {0}",new Object[]{fullname});
+        		user.setFullName(fullname);
+        	} else {
+        		LOGGER.log(Level.FINE,"Null or empty user name : not updating it");
+        	}
+        } else {
+        	LOGGER.log(Level.FINE,"None strategy : not updating the user's name");
+        }
+
+        if ( !OPTION_RESOLVER_NONESTRATEGY.equals(emailResolver) ) {
+            Mailer.UserProperty existing = user.getProperty(Mailer.UserProperty.class);
+            if (existing==null || !existing.hasExplicitlyConfiguredAddress()) {
+	        	String email = null;
+	        	if ( OPTION_RESOLVER_DEFAULTSTRATEGY.equals(emailResolver) ) {
+	        		LOGGER.log(Level.FINE,"Calling any registered MailAddressResolver for {0}",new Object[]{user});
+	        		email = MailAddressResolver.resolve(user);
+	        	} else {
+	                for (MailAddressResolver mar : MailAddressResolver.all()) {
+	                	if ( mar.getClass().getName().equals(emailResolver) ) {
+	                		LOGGER.log(Level.FINE,"Calling resolver {0} for {1}",new Object[]{emailResolver,user});
+	                		email = mar.findMailAddressFor(user);
+	                		break;
+	                	}
+                		LOGGER.log(Level.WARNING,"Resolver {0} not found : e-mail not updated",new Object[]{emailResolver});
+	                }
+	        	}
+	        	if ( StringUtils.isNotBlank(email) ) {
+	                try {
+	              		LOGGER.log(Level.FINE,"Setting e-mail to {0}",new Object[]{email});
+	                	user.addProperty(new Mailer.UserProperty(email));
+	                } catch (IOException e){
+	                	LOGGER.throwing(ScriptSecurityRealm.class.getCanonicalName(), "updateUserDetails", e);
+	                }
+	        	} else {
+	        		LOGGER.log(Level.FINE,"Null or empty e-mail : not updating it");
+	        	}
+            } else {
+            	LOGGER.log(Level.FINE,"An e-mail has already been set up by the user : not updating it");
+            }
+        } else {
+        	LOGGER.log(Level.FINE,"None strategy : not updating the e-mail");
+        }
+    }
 
 	public boolean isWindows() {
 		String os = System.getProperty("os.name").toLowerCase();

--- a/src/main/java/hudson/plugins/script_realm/ScriptSecurityRealm.java
+++ b/src/main/java/hudson/plugins/script_realm/ScriptSecurityRealm.java
@@ -72,7 +72,7 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 	private static final Logger LOGGER = Logger.getLogger(ScriptSecurityRealm.class.getName());
 
 	/** Strategy : call the global resolve method (let Jenkins choose) */
-	private static final String OPTION_RESOLVER_DEFAULTSTRATEGY = "*";
+	private static final String OPTION_RESOLVER_ANYSTRATEGY = "*";
 	/** Strategy : don't resolve */
 	private static final String OPTION_RESOLVER_NONESTRATEGY = "";
 
@@ -150,19 +150,19 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 		}
 
 		public String getDefaultEmailResolver() {
-			return OPTION_RESOLVER_DEFAULTSTRATEGY;
+			return OPTION_RESOLVER_NONESTRATEGY;
 		}
 
 		public String getDefaultNameResolver() {
-			return OPTION_RESOLVER_DEFAULTSTRATEGY;
+			return OPTION_RESOLVER_NONESTRATEGY;
 		}
 
 		public ListBoxModel doFillEmailResolverItems() {
             ListBoxModel items = new ListBoxModel();
             ExtensionList<MailAddressResolver> mars = MailAddressResolver.all();
-            items.add(new Option(Messages.ScriptSecurityRealm_EmailResolver_defaultstrategy_label(),OPTION_RESOLVER_DEFAULTSTRATEGY));	// This entry will use Jenkins's default behavior (calling all found resolvers)
+            items.add(new Option(Messages.ScriptSecurityRealm_EmailResolver_nonestrategy_label(),OPTION_RESOLVER_NONESTRATEGY));	// This entry will disable resolving if selected
             if ( ! mars.isEmpty() ) {
-                items.add(new Option(Messages.ScriptSecurityRealm_EmailResolver_nonestrategy_label(),OPTION_RESOLVER_NONESTRATEGY));	// This entry will disable resolving if selected
+                items.add(new Option(Messages.ScriptSecurityRealm_EmailResolver_anystrategy_label(),OPTION_RESOLVER_ANYSTRATEGY));	// This entry will use Jenkins's default behavior (calling all found resolvers)
 	            // Adds all found e-mail resolvers as options so the user can select one of them
 	            for (MailAddressResolver mar : mars) {
 	            	// class name is used both as label and value
@@ -175,9 +175,9 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 		public ListBoxModel doFillNameResolverItems() {
             ListBoxModel items = new ListBoxModel();
             ExtensionList<UserNameResolver> unrs = UserNameResolver.all();
-            items.add(new Option(Messages.ScriptSecurityRealm_NameResolver_defaultstrategy_label(),OPTION_RESOLVER_DEFAULTSTRATEGY));	// This entry will use Jenkins's default behavior (calling all found resolvers)
+            items.add(new Option(Messages.ScriptSecurityRealm_NameResolver_nonestrategy_label(),OPTION_RESOLVER_NONESTRATEGY));	// This entry will disable resolving if selected
             if ( ! unrs.isEmpty() ) {
-                items.add(new Option(Messages.ScriptSecurityRealm_NameResolver_nonestrategy_label(),OPTION_RESOLVER_NONESTRATEGY));	// This entry will disable resolving if selected
+                items.add(new Option(Messages.ScriptSecurityRealm_NameResolver_anystrategy_label(),OPTION_RESOLVER_ANYSTRATEGY));	// This entry will use Jenkins's default behavior (calling all found resolvers)
 	            // Adds all found name resolvers as options so the user can select one of them
 	            for (UserNameResolver unr : unrs) {
 	            	// class name is used both as label and value
@@ -233,7 +233,7 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 
         if ( !OPTION_RESOLVER_NONESTRATEGY.equals(nameResolver) ) {
         	String fullname = null;
-        	if ( OPTION_RESOLVER_DEFAULTSTRATEGY.equals(nameResolver) ) {
+        	if ( OPTION_RESOLVER_ANYSTRATEGY.equals(nameResolver) ) {
         		LOGGER.log(Level.FINE,"Calling any registered UserNameResolver for {0}",new Object[]{user});
         		fullname = UserNameResolver.resolve(user);
         	} else {
@@ -260,7 +260,7 @@ public class ScriptSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             Mailer.UserProperty existing = user.getProperty(Mailer.UserProperty.class);
             if (existing==null || !existing.hasExplicitlyConfiguredAddress()) {
 	        	String email = null;
-	        	if ( OPTION_RESOLVER_DEFAULTSTRATEGY.equals(emailResolver) ) {
+	        	if ( OPTION_RESOLVER_ANYSTRATEGY.equals(emailResolver) ) {
 	        		LOGGER.log(Level.FINE,"Calling any registered MailAddressResolver for {0}",new Object[]{user});
 	        		email = MailAddressResolver.resolve(user);
 	        	} else {

--- a/src/main/resources/hudson/plugins/script_realm/Messages.properties
+++ b/src/main/resources/hudson/plugins/script_realm/Messages.properties
@@ -1,5 +1,7 @@
+# Plugin's title in /configureSecurity/ section
+ScriptSecurityRealm.displayName=Authenticate via custom script
 # Labels for the strategies in the drop-down list
-ScriptSecurityRealm.EmailResolver.nonestrategy.label=Default (do not resolve)
+ScriptSecurityRealm.EmailResolver.nonestrategy.label=None (do not resolve)
 ScriptSecurityRealm.EmailResolver.anystrategy.label=Any (try all existing resolvers)
-ScriptSecurityRealm.NameResolver.nonestrategy.label=Default (do not resolve)
+ScriptSecurityRealm.NameResolver.nonestrategy.label=None (do not resolve)
 ScriptSecurityRealm.NameResolver.anystrategy.label=Any (try all existing resolvers)

--- a/src/main/resources/hudson/plugins/script_realm/Messages.properties
+++ b/src/main/resources/hudson/plugins/script_realm/Messages.properties
@@ -1,5 +1,5 @@
 # Labels for the strategies in the drop-down list
-ScriptSecurityRealm.EmailResolver.defaultstrategy.label=Default (try all existing resolvers)
-ScriptSecurityRealm.EmailResolver.nonestrategy.label=None (do not resolve)
-ScriptSecurityRealm.NameResolver.defaultstrategy.label=Default (try all existing resolvers)
-ScriptSecurityRealm.NameResolver.nonestrategy.label=None (do not resolve)
+ScriptSecurityRealm.EmailResolver.nonestrategy.label=Default (do not resolve)
+ScriptSecurityRealm.EmailResolver.anystrategy.label=Any (try all existing resolvers)
+ScriptSecurityRealm.NameResolver.nonestrategy.label=Default (do not resolve)
+ScriptSecurityRealm.NameResolver.anystrategy.label=Any (try all existing resolvers)

--- a/src/main/resources/hudson/plugins/script_realm/Messages.properties
+++ b/src/main/resources/hudson/plugins/script_realm/Messages.properties
@@ -1,0 +1,5 @@
+# Labels for the strategies in the drop-down list
+ScriptSecurityRealm.EmailResolver.defaultstrategy.label=Default (try all existing resolvers)
+ScriptSecurityRealm.EmailResolver.nonestrategy.label=None (do not resolve)
+ScriptSecurityRealm.NameResolver.defaultstrategy.label=Default (try all existing resolvers)
+ScriptSecurityRealm.NameResolver.nonestrategy.label=None (do not resolve)

--- a/src/main/resources/hudson/plugins/script_realm/Messages_fr.properties
+++ b/src/main/resources/hudson/plugins/script_realm/Messages_fr.properties
@@ -1,0 +1,4 @@
+ScriptSecurityRealm.EmailResolver.nonestrategy.label=Défaut (ne pas résoudre)
+ScriptSecurityRealm.EmailResolver.anystrategy.label=Tout essayer (le premier qui fonctionne)
+ScriptSecurityRealm.NameResolver.nonestrategy.label=Défaut (ne pas résoudre)
+ScriptSecurityRealm.NameResolver.anystrategy.label=Tout essayer (le premier qui fonctionne)

--- a/src/main/resources/hudson/plugins/script_realm/Messages_fr.properties
+++ b/src/main/resources/hudson/plugins/script_realm/Messages_fr.properties
@@ -1,4 +1,5 @@
-ScriptSecurityRealm.EmailResolver.nonestrategy.label=Défaut (ne pas résoudre)
-ScriptSecurityRealm.EmailResolver.anystrategy.label=Tout essayer (le premier qui fonctionne)
-ScriptSecurityRealm.NameResolver.nonestrategy.label=Défaut (ne pas résoudre)
-ScriptSecurityRealm.NameResolver.anystrategy.label=Tout essayer (le premier qui fonctionne)
+ScriptSecurityRealm.displayName=Authentification par script
+ScriptSecurityRealm.EmailResolver.nonestrategy.label=Aucun (ne pas résoudre)
+ScriptSecurityRealm.EmailResolver.anystrategy.label=Tous (tout essayer)
+ScriptSecurityRealm.NameResolver.nonestrategy.label=Aucun (ne pas résoudre)
+ScriptSecurityRealm.NameResolver.anystrategy.label=Tous (tout essayer)

--- a/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/config.jelly
+++ b/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/config.jelly
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="${%Login Command}">
+  <f:entry title="${%Login Command}" help="/plugin/script-realm/help-commandLine.html">
     <f:textbox field="commandLine" />
   </f:entry>
   <f:entry title="${%Groups Command}" help="/plugin/script-realm/help-groupsCommandLine.html">

--- a/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/config.jelly
+++ b/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/config.jelly
@@ -31,4 +31,10 @@ THE SOFTWARE.
   <f:entry title="${%Groups Delimiter}" help="/plugin/script-realm/help-groupsDelimiter.html">
     <f:textbox field="groupsDelimiter" default="," />
   </f:entry>
+  <f:entry field="emailResolver" title="${%Email resolver}" help="/plugin/script-realm/help-emailResolver.html">
+    <f:select default="${descriptor.defaultEmailResolver()}" />
+  </f:entry>
+  <f:entry field="nameResolver" title="${%Name resolver}" help="/plugin/script-realm/help-nameResolver.html">
+    <f:select default="${descriptor.defaultNameResolver()}" />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/config_fr.properties
+++ b/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/config_fr.properties
@@ -1,0 +1,5 @@
+Login\ Command=Commande pour authentifier
+Groups\ Command=Commande pour résoudre les groupes
+Groups\ Delimiter=Délimiteur de groupes
+Email\ resolver=Résolveur d'e-mail
+Name\ resolver=Résolveur de nom

--- a/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/config_fr.properties
+++ b/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/config_fr.properties
@@ -1,5 +1,5 @@
 Login\ Command=Commande pour authentifier
 Groups\ Command=Commande pour résoudre les groupes
 Groups\ Delimiter=Délimiteur de groupes
-Email\ resolver=Résolveur d'e-mail
+Email\ resolver=Résolveur d\u2019e-mail
 Name\ resolver=Résolveur de nom

--- a/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help.html
+++ b/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help.html
@@ -1,15 +1,4 @@
 <div>
   Delegates the authentication to a custom script. This is useful if you need to plug into
   a custom authentication scheme, but don't want to write your own plugin.
-
-  <p>
-  Each time the authentication is attempted (which is once per session),
-  the specified script will be invoked with the username in the 'U' environment variable
-  and the password in the 'P' environment variable. If the script returns exit code 0,
-  the authentication is considered successful, and otherwise failure.
-  </p>
-
-  <p>
-  In case of failure, the output from the process will be reported in the exception message.
-  </p>
 </div>

--- a/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help.html
+++ b/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help.html
@@ -10,6 +10,6 @@
   </p>
 
   <p>
-  In case of the failure, the output from the process will be reported in the exception message.
+  In case of failure, the output from the process will be reported in the exception message.
   </p>
 </div>

--- a/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help.html
+++ b/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help.html
@@ -3,11 +3,13 @@
   a custom authentication scheme, but don't want to write your own plugin.
 
   <p>
-  Each time the authentication is attemped (which is once per session),
+  Each time the authentication is attempted (which is once per session),
   the specified script will be invoked with the username in the 'U' environment variable
   and the password in the 'P' environment variable. If the script returns exit code 0,
   the authentication is considered successful, and otherwise failure.
+  </p>
 
   <p>
   In case of the failure, the output from the process will be reported in the exception message.
+  </p>
 </div>

--- a/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help_fr.html
+++ b/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help_fr.html
@@ -1,0 +1,16 @@
+<div>
+  Délègue l'authentification à un script.
+  Cela permet par ex. de se connecter à un mécanisme d'authentification non standard.
+</div>
+
+  <p>
+  A chaque tentative d'authentification (c.a.d. une fois par session),
+  le script spécifié sera invoqué et recevra l'identifiant dans la variable d'environnement 'U'
+  et le mot de passe dans la variable d'environnement 'P'.
+  L'authentification est considérée réussie si le processus sort avec le statut 0, 
+  sinon elle est considérée en échec.
+  </p>
+
+  <p>
+  En cas d'échec, le texte affiché par le script sera rapporté dans le message d'erreur.
+  </p>

--- a/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help_fr.html
+++ b/src/main/resources/hudson/plugins/script_realm/ScriptSecurityRealm/help_fr.html
@@ -2,15 +2,3 @@
   Délègue l'authentification à un script.
   Cela permet par ex. de se connecter à un mécanisme d'authentification non standard.
 </div>
-
-  <p>
-  A chaque tentative d'authentification (c.a.d. une fois par session),
-  le script spécifié sera invoqué et recevra l'identifiant dans la variable d'environnement 'U'
-  et le mot de passe dans la variable d'environnement 'P'.
-  L'authentification est considérée réussie si le processus sort avec le statut 0, 
-  sinon elle est considérée en échec.
-  </p>
-
-  <p>
-  En cas d'échec, le texte affiché par le script sera rapporté dans le message d'erreur.
-  </p>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <div>
   This plugin adds authentication and groups resolving via user-defined script.
-  In addition to the original script-realm, this one also supports e-mail and name resolving through the use of existing plugins.
+  It also supports e-mail and name resolving through the use of existing plugins.
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
 <div>
-  This plugin adds authentication via user-defined script, in additon to the orignal script-realm, this one also supports groups.
+  This plugin adds authentication and groups resolving via user-defined script.
+  In addition to the original script-realm, this one also supports e-mail and name resolving through the use of existing plugins.
 </div>

--- a/src/main/webapp/help-commandLine.html
+++ b/src/main/webapp/help-commandLine.html
@@ -1,0 +1,9 @@
+<div>
+  Each time the authentication is attempted (which is once per session),
+  this script will be invoked with the username in the 'U' environment variable
+  and the password in the 'P' environment variable. If the script returns exit code 0,
+  the authentication is considered successful, and otherwise failed.
+  <br />
+  <br />
+  In case of failure, the output from the process will be reported in the exception message.
+</div>

--- a/src/main/webapp/help-commandLine_fr.html
+++ b/src/main/webapp/help-commandLine_fr.html
@@ -1,0 +1,10 @@
+<div>
+  A chaque tentative d'authentification (c.a.d. une fois par session),
+  ce script sera invoqué et recevra l'identifiant dans la variable d'environnement 'U'
+  et le mot de passe dans la variable d'environnement 'P'.
+  L'authentification est considérée réussie si le processus sort avec le statut 0, 
+  sinon elle est considérée en échec.
+  <br />
+  <br />
+  En cas d'échec, le texte affiché par le script sera rapporté dans le message d'erreur.
+</div>

--- a/src/main/webapp/help-emailResolver.html
+++ b/src/main/webapp/help-emailResolver.html
@@ -1,5 +1,8 @@
 <div>
-    Choose how to resolve the e-mail of the authenticated user (you may want to install specific plugins to get more options).<br />
-    If none, e-mail will not be resolved by this plugin.<br />
-    Be aware that not all options may work, as they may come from external plugins with their own configuration strategy.<br />
+    Choose how to resolve the e-mail of the authenticated user (you may want to install other plugins to get more options).<br />
+	<br />
+    If "none", e-mail will not be resolved by this plugin (default).<br />
+   	If "any", Jenkins will choose the 1st working resolver.<br />
+	<br />
+    Be aware that some options may not work if they come from plugins with their own configuration strategy.<br />
 </div>

--- a/src/main/webapp/help-emailResolver.html
+++ b/src/main/webapp/help-emailResolver.html
@@ -1,5 +1,5 @@
 <div>
     Choose how to resolve the e-mail of the authenticated user (you may want to install specific plugins to get more options).<br />
-    If none, e-mail will not be resolved (it will stay as is).<br />
+    If none, e-mail will not be resolved by this plugin.<br />
     Be aware that not all options may work, as they may come from external plugins with their own configuration strategy.<br />
 </div>

--- a/src/main/webapp/help-emailResolver.html
+++ b/src/main/webapp/help-emailResolver.html
@@ -1,5 +1,5 @@
 <div>
-    Choose how to resolve the e-mail of the authenticated user (you may want to install plugins to increase the available options).<br />
-    If none, no e-mail resolution will be attempted (it will stay as is).<br />
-    Be aware that not all options may work, as they may come from a plugin that follows its own configuration strategy.<br />
+    Choose how to resolve the e-mail of the authenticated user (you may want to install specific plugins to get more options).<br />
+    If none, e-mail will not be resolved (it will stay as is).<br />
+    Be aware that not all options may work, as they may come from external plugins with their own configuration strategy.<br />
 </div>

--- a/src/main/webapp/help-emailResolver.html
+++ b/src/main/webapp/help-emailResolver.html
@@ -1,0 +1,5 @@
+<div>
+    Choose how to resolve the e-mail of the authenticated user (you may want to install plugins to increase the available options).<br />
+    If none, no e-mail resolution will be attempted (it will stay as is).<br />
+    Be aware that not all options may work, as they may come from a plugin that follows its own configuration strategy.<br />
+</div>

--- a/src/main/webapp/help-emailResolver_fr.html
+++ b/src/main/webapp/help-emailResolver_fr.html
@@ -1,0 +1,5 @@
+<div>
+	Choisissez la manière de résoudre l'e-mail de la personne authentifiée (vous pouvez installer d'autres plugins pour agrandir la liste).<br />
+	Si vide, les e-mails ne seront pas résolus par ce plugin.<br />
+	Certaines combinaisons peuvent ne pas fonctionner, car les résolveurs peuvent provenir de plugins disposant de leur propre stratégie de configuration.<br />
+</div>

--- a/src/main/webapp/help-emailResolver_fr.html
+++ b/src/main/webapp/help-emailResolver_fr.html
@@ -1,5 +1,8 @@
 <div>
 	Choisissez la manière de résoudre l'e-mail de la personne authentifiée (vous pouvez installer d'autres plugins pour agrandir la liste).<br />
-	Si vide, les e-mails ne seront pas résolus par ce plugin.<br />
-	Certaines combinaisons peuvent ne pas fonctionner, car les résolveurs peuvent provenir de plugins disposant de leur propre stratégie de configuration.<br />
+	<br />
+	Si "aucun", les e-mails ne seront pas résolus par ce plugin (choix par défaut).<br />
+	Si "tous", Jenkins choisira le 1er résolveur fonctionnel.<br />
+	<br />
+	Notez que certains choix peuvent ne pas fonctionner s'ils proviennent de plugins disposant de leur propre stratégie de configuration.<br />
 </div>

--- a/src/main/webapp/help-groupsCommandLine.html
+++ b/src/main/webapp/help-groupsCommandLine.html
@@ -2,11 +2,12 @@
   Delegates the groups resolution to a custom script.
   
   <p>
-  Each time the authentication is attemped (which is once per session),
-  the specified script will be invoked with the username in the 'U' environment variable.
+  Each time the authentication is attempted, this script will be invoked with the username in the 'U' environment variable.
   If the script returns exit code 0, the output will be tokenized by the delimiter (default: ',')
   to create a group with each token.
+  </p>
 
   <p>
-  In case of the failure, the output from the process will be reported in the exception message.
+  In case of failure, the output from the process will be reported in the exception message.
+  </p>
 </div>

--- a/src/main/webapp/help-groupsCommandLine.html
+++ b/src/main/webapp/help-groupsCommandLine.html
@@ -1,13 +1,10 @@
 <div>
-  Delegates the groups resolution to a custom script.
+  If not empty, delegates the groups resolution to a custom script.
   
   <p>
   Each time the authentication is attempted, this script will be invoked with the username in the 'U' environment variable.
-  If the script returns exit code 0, the output will be tokenized by the delimiter (default: ',')
-  to create a group with each token.
+  If the script returns exit code 0, the output will be tokenized by the delimiter to create a group with each token.
   </p>
 
-  <p>
   In case of failure, the output from the process will be reported in the exception message.
-  </p>
 </div>

--- a/src/main/webapp/help-groupsCommandLine_fr.html
+++ b/src/main/webapp/help-groupsCommandLine_fr.html
@@ -1,0 +1,13 @@
+<div>
+  Délègue la résolution des groupes à un script.
+  
+  <p>
+  A chaque tentative d'authentification, ce script sera invoqué et recevra l'identifiant dans la variable d'environnement 'U'.
+  Si le processus sort avec le statut 0, sa sortie standard sera interprétée comme l'ensemble des groupes
+  de l'utilisateur, séparés par le délimiteur (défaut: ','). 
+  </p>
+
+  <p>
+  En cas d'échec, le texte affiché par le script sera rapporté dans le message d'erreur.
+  </p>
+</div>

--- a/src/main/webapp/help-groupsCommandLine_fr.html
+++ b/src/main/webapp/help-groupsCommandLine_fr.html
@@ -1,13 +1,11 @@
 <div>
-  Délègue la résolution des groupes à un script.
+  Si non vide, délègue la résolution des groupes à un script.
   
   <p>
   A chaque tentative d'authentification, ce script sera invoqué et recevra l'identifiant dans la variable d'environnement 'U'.
   Si le processus sort avec le statut 0, sa sortie standard sera interprétée comme l'ensemble des groupes
-  de l'utilisateur, séparés par le délimiteur (défaut: ','). 
+  de l'utilisateur, séparés par le délimiteur. 
   </p>
 
-  <p>
   En cas d'échec, le texte affiché par le script sera rapporté dans le message d'erreur.
-  </p>
 </div>

--- a/src/main/webapp/help-groupsDelimiter.html
+++ b/src/main/webapp/help-groupsDelimiter.html
@@ -1,3 +1,3 @@
 <div>
-  Delimiter to split the groups within the returned output of the groups script.
+  Delimiter to split the groups within the returned output of the groups script (default: '<code>,</code>').
 </div>

--- a/src/main/webapp/help-groupsDelimiter_fr.html
+++ b/src/main/webapp/help-groupsDelimiter_fr.html
@@ -1,3 +1,3 @@
 <div>
-  Délimiteur utilisé pour séparer les groupes dans la sortie du script de résolution des groupes.
+  Délimiteur utilisé pour séparer les groupes dans la sortie du script de résolution des groupes (défaut: '<code>,</code>').
 </div>

--- a/src/main/webapp/help-groupsDelimiter_fr.html
+++ b/src/main/webapp/help-groupsDelimiter_fr.html
@@ -1,0 +1,3 @@
+<div>
+  Délimiteur utilisé pour séparer les groupes dans la sortie du script de résolution des groupes.
+</div>

--- a/src/main/webapp/help-nameResolver.html
+++ b/src/main/webapp/help-nameResolver.html
@@ -1,5 +1,5 @@
 <div>
     Choose how to resolve the full name of the authenticated user (you may want to install specific plugins to get more options).<br />
-    If none, the full name will not be resolved (it will stay as is).<br />
+    If none, the full name will not be resolved by this plugin.<br />
     Be aware that not all options may work, as they may come from external plugins with their own configuration strategy.<br />
 </div>

--- a/src/main/webapp/help-nameResolver.html
+++ b/src/main/webapp/help-nameResolver.html
@@ -1,5 +1,9 @@
 <div>
-    Choose how to resolve the full name of the authenticated user (you may want to install specific plugins to get more options).<br />
-    If none, the full name will not be resolved by this plugin.<br />
-    Be aware that not all options may work, as they may come from external plugins with their own configuration strategy.<br />
+    Choose how to resolve the full name of the authenticated user (you may want to install specific plugins to get more options).
+   	<br />
+	<br />
+    If "none", the name will not be resolved by this plugin (default).<br />
+   	If "any", Jenkins will choose the 1st working resolver.<br />
+   	<br />
+    Be aware that some options may not work if they come from plugins with their own configuration strategy.<br />
 </div>

--- a/src/main/webapp/help-nameResolver.html
+++ b/src/main/webapp/help-nameResolver.html
@@ -1,0 +1,5 @@
+<div>
+    Choose how to resolve the full name of the authenticated user (you may want to install plugins to increase the available options).<br />
+    If none, no name resolution will be attempted (it will stay as is).<br />
+    Be aware that not all options may work, as they may come from a plugin that follows its own configuration strategy.<br />
+</div>

--- a/src/main/webapp/help-nameResolver.html
+++ b/src/main/webapp/help-nameResolver.html
@@ -1,5 +1,5 @@
 <div>
-    Choose how to resolve the full name of the authenticated user (you may want to install plugins to increase the available options).<br />
-    If none, no name resolution will be attempted (it will stay as is).<br />
-    Be aware that not all options may work, as they may come from a plugin that follows its own configuration strategy.<br />
+    Choose how to resolve the full name of the authenticated user (you may want to install specific plugins to get more options).<br />
+    If none, the full name will not be resolved (it will stay as is).<br />
+    Be aware that not all options may work, as they may come from external plugins with their own configuration strategy.<br />
 </div>

--- a/src/main/webapp/help-nameResolver_fr.html
+++ b/src/main/webapp/help-nameResolver_fr.html
@@ -1,0 +1,5 @@
+<div>
+	Choisissez la manière de résoudre le nom complet de la personne authentifiée (vous pouvez installer d'autres plugins pour agrandir la liste).<br />
+	Si vide, le nom complet ne sera pas résolu par ce plugin.<br />
+	Certaines combinaisons peuvent ne pas fonctionner, car les résolveurs peuvent provenir de plugins disposant de leur propre stratégie de configuration.<br />
+</div>

--- a/src/main/webapp/help-nameResolver_fr.html
+++ b/src/main/webapp/help-nameResolver_fr.html
@@ -1,5 +1,8 @@
 <div>
 	Choisissez la manière de résoudre le nom complet de la personne authentifiée (vous pouvez installer d'autres plugins pour agrandir la liste).<br />
-	Si vide, le nom complet ne sera pas résolu par ce plugin.<br />
-	Certaines combinaisons peuvent ne pas fonctionner, car les résolveurs peuvent provenir de plugins disposant de leur propre stratégie de configuration.<br />
+	<br />
+	Si "aucun", le nom ne sera pas résolu par ce plugin (choix par défaut).<br />
+	Si "tous", Jenkins choisira le 1er résolveur fonctionnel.<br />
+   	<br />
+	Notez que certains choix peuvent ne pas fonctionner s'ils proviennent de plugins disposant de leur propre stratégie de configuration.<br />
 </div>

--- a/src/test/java/hudson/plugins/script_realm/ScriptSecurityRealmTest.java
+++ b/src/test/java/hudson/plugins/script_realm/ScriptSecurityRealmTest.java
@@ -28,7 +28,7 @@ public class ScriptSecurityRealmTest extends HudsonTestCase {
 	}
 
 	public void test1() {
-		UserDetails user = new ScriptSecurityRealm(trueScript.getAbsolutePath(), null, null).authenticate("test", "test");
+		UserDetails user = new ScriptSecurityRealm(trueScript.getAbsolutePath(), null, null, null, null).authenticate("test", "test");
 		System.out.println("**-->" + user);
 		assertTrue("user account not enabled", user.isEnabled());
 		assertTrue("user credentials expired", user.isCredentialsNonExpired());
@@ -38,7 +38,7 @@ public class ScriptSecurityRealmTest extends HudsonTestCase {
 
 	public void test2() {
 		try {
-			new ScriptSecurityRealm(falseScript.getAbsolutePath(), null, null).authenticate("test", "test");
+			new ScriptSecurityRealm(falseScript.getAbsolutePath(), null, null, null, null).authenticate("test", "test");
 			fail();
 		} catch (AuthenticationException e) {
 			// as expected

--- a/src/test/resources/DeleteAllUsers.groovy
+++ b/src/test/resources/DeleteAllUsers.groovy
@@ -1,0 +1,17 @@
+import hudson.security.*
+import jenkins.security.*
+
+//
+// USE ONLY ON LOCAL JENKINS FOR TESTS !!!
+// DELETES ALL USERS FROM JENKINS !!!!
+//
+
+for ( userInfo in Jenkins.instance.getPeople().users ) {
+    User user = userInfo.getUser()
+    print("Deleting user "+user)
+    user.delete()
+}
+
+for ( userInfo in Jenkins.instance.getPeople().users ) {
+    println(userInfo.getUser())
+}


### PR DESCRIPTION
This branch adds localization and french translation :
- inline help is now localized (except in the plugin's list)
- added french translation
- part of the main help has moved under the 'Login command' section, as the plugin now does more than just authentication (i.e. groups & e-mail/name resolving)

As I developed it, it's bound to another proposed evolution (pull request #2), because it adds new parameters to localize that would not be present if forked directly from the current master of the project.

With some extra work code may be isolated (i.e. i18n for existing fields + separate commits on branch #2 for new fields) but I'll wait for your feedback before going further.
